### PR TITLE
USWDS-Team: Add Github action add-to-project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/uswds/projects/8
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ secrets.TEST_ORG_RW }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add all issues to project board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/uswds/projects/8
+          github-token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
### Description
Related to issue https://github.com/uswds/uswds-team/issues/176

### Purpose
Add the Github [add-to-project](https://github.com/marketplace/actions/add-to-github-projects-beta) action to our repos so that newly opened issues are automatically added to our project board. 

Note: I am implementing this on this repo first to confirm desired behavior before moving to our more public repos. 

### Demo and testing
This action works successfully on my[ personal test repo](https://github.com/amyleadem/issue-template/blob/main/.github/workflows/add-to-project.yml). To test on this repo: 
1. First [open a new issue](https://github.com/amyleadem/issue-template/issues/new/choose)
1. See that the new issue is automatically added to the sample [project board](https://github.com/users/amyleadem/projects/1)

To test on this repo:
1. Merge this PR
2. Open a new issue
3. See if it lands on our project board