### PR TITLE
USWDS-Team: Update add-to-project GitHub action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/uswds/projects/8
-          github-token: ${{ secrets.TEST_ORG_RW }}
+          github-token: ${{ secrets.ADD_TO_PROJECT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v0.1.0
         with:
           project-url: https://github.com/orgs/uswds/projects/8
           github-token: ${{ secrets.ADD_TO_PROJECT }}


### PR DESCRIPTION
Purpose: 
The GitHub action [add-to-project](https://github.com/marketplace/actions/add-to-github-projects-beta) updated this morning and now has new requirements for the PAT used in the `github-token`.
1. Update the `github-token` used to one with correct PAT scope
1. Pin the version of the GitHub action to current version to prevent future breaks