### PR TITLE
USWDS-Team - GH Actions: Remove space from POAM labels

### DIFF
--- a/.github/workflows/POAM.yml
+++ b/.github/workflows/POAM.yml
@@ -21,7 +21,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TITLE: POAM - [MONTH] '24
-          LABELS: "Role: Dev, Type: Task"
+          LABELS: "Role: Dev,Type: Task"
           BODY: |
             # Summary
 


### PR DESCRIPTION
# Summary

Removed the space separating labels. 

## Issue statement

This space is believed to cause an error during runtime, which caused the script to exit.

![image](https://github.com/user-attachments/assets/44bbe4fd-b3c6-4214-a900-2ab1add9c34d)

## Solution

Remove whitespace from comma-separated list.

## Testing

1. Rerun this [taskrunner](https://github.com/uswds/uswds-team/actions/runs/10189490586/job/28187626145)
2. Confirm issue is created without error.