### PR TITLE
USWDS-Team - GH Actions: Add manual workflow dispatch to POAM job

### DIFF
--- a/.github/workflows/POAM.yml
+++ b/.github/workflows/POAM.yml
@@ -2,6 +2,7 @@ name: Monthly Security POAM
 on:
   schedule:
     - cron: 0 0 1 * *
+  workflow_dispatch:
 
 jobs:
   create_issue:


### PR DESCRIPTION
# Summary

Added the option to manually run the POAM workflow for testing purposes.

## Problem statement

There is currently no easy way to test the GH action is running without waiting for the first of the month

## Proposed solution

Add [workflow_dispatch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) to the yml file.

This allows us to manually run the workflow via a button on the job description page.

![image](https://github.com/user-attachments/assets/65c7650b-203a-4369-bc96-5bd937128efb)

GH Docs: [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)