### PR TITLE
USWDS-Team - POAM: Use dynamic date in issue creation

### DIFF
--- a/.github/workflows/POAM.yml
+++ b/.github/workflows/POAM.yml
@@ -1,4 +1,4 @@
-name: Monthly Security POAM
+name: Testing - POAM w/ dynamic dates
 on:
   schedule:
     - cron: 0 0 1 * *
@@ -8,9 +8,9 @@ jobs:
   create_issue:
     name: Create monthly POAM issue
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
+      - name: Dynamically set DATE environment variable
+        run: echo "DATE=$(date '+%B %Y')" >> $GITHUB_ENV
       - name: Create monthly POAM issue
         run: |
           new_issue_url=$(gh issue create \
@@ -18,20 +18,21 @@ jobs:
             --assignee "$ASSIGNEES" \
             --label "$LABELS" \
             --body "$BODY")
+            
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TITLE: POAM - [MONTH] '24
-          LABELS: "Role: Dev,Type: Task"
+          TITLE: TEST - ${{ env.DATE }}
+          LABELS: "Role: Dev,Type: Task,Status: Triage"
           BODY: |
             # Summary
-
-            POAM for [MONTH] 2024
+        
+            POAM update tracker for ${{ env.DATE }}
 
             - [ ] USWDS
             - [ ] USWDS-Site
-            - [ ] USWDS-Sandbox
-            - [ ] USWDS-Next
+            - [ ] Web-Components
             - [ ] USWDS-Compile
+            - [ ] USWDS-Sandbox
             - [ ] USWDS-Tutorial
             - [ ] Public Sans

--- a/.github/workflows/POAM.yml
+++ b/.github/workflows/POAM.yml
@@ -1,4 +1,4 @@
-name: Testing - POAM w/ dynamic dates
+name: Monthly Security POAM
 on:
   schedule:
     - cron: 0 0 1 * *
@@ -8,6 +8,8 @@ jobs:
   create_issue:
     name: Create monthly POAM issue
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Dynamically set DATE environment variable
         run: echo "DATE=$(date '+%B %Y')" >> $GITHUB_ENV
@@ -22,11 +24,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TITLE: TEST - ${{ env.DATE }}
+          TITLE: POAM - ${{ env.DATE }}
           LABELS: "Role: Dev,Type: Task,Status: Triage"
           BODY: |
             # Summary
-        
+
             POAM update tracker for ${{ env.DATE }}
 
             - [ ] USWDS

--- a/.github/workflows/POAM.yml
+++ b/.github/workflows/POAM.yml
@@ -29,7 +29,7 @@ jobs:
           BODY: |
             # Summary
 
-            POAM update tracker for ${{ env.DATE }}
+            POAM update tracker
 
             - [ ] USWDS
             - [ ] USWDS-Site


### PR DESCRIPTION
# Summary

Updated POAM GitHub workflow to dynamically set the month and year and add the `triage` label. Now, team members will no longer have to manually update to match the current date.

## Related issue

Closes #416 

## Problem statement

Automatic POAM issue creation lacks meta data and includes hard coded values

## Solution

- Use dynamic value setting to automatically set the month and year of the issue summary and title. 
- Add `triage` label to label list

## Testing and review

1. Visit [test issue](https://github.com/uswds/uswds-team/issues/453) and confirm the description matches expectations
2. Review [test workflow](https://github.com/uswds/uswds-team/actions/workflows/TEST-dynamic-dates.yml) and confirm it runs as expected

> [!NOTE]
> Test workflow also attempts the add the issue to our project board. This is currently not possible and may be resolved via #458

> [!IMPORTANT]
> After merge, we should delete the [cm-POAM-test-workflow](https://github.com/uswds/uswds-team/tree/cm-POAM-test-workflow) branch to remove the test workflow from our [actions page](https://github.com/uswds/uswds-team/actions)


